### PR TITLE
Scale range should exclude margins

### DIFF
--- a/01_Visitor_Dashboard/lib/charts/BarChart.jsx
+++ b/01_Visitor_Dashboard/lib/charts/BarChart.jsx
@@ -43,7 +43,7 @@ var BarChart=React.createClass({
 
         var y=d3.scale.linear()
             .domain([0,100])
-            .range([this.props.height,0]);
+            .range([h,0]);
 
 
         var rectBackground=(data).map(function(d, i) {


### PR DESCRIPTION
Since below we have a `<rect height={h-y(d.value)} ...>`, `y(d.value)` must never excess `h`. Because of margins, currently it can and will produce 

```
DOMPropertyOperations.js:147Error: <rect> attribute height: A negative value is not valid. (...)
```
